### PR TITLE
support generating sql statements with the proper formatting for tabl…

### DIFF
--- a/test/automated/handler/formatting/quote_columns.rb
+++ b/test/automated/handler/formatting/quote_columns.rb
@@ -1,0 +1,16 @@
+require_relative '../../automated_init'
+
+context 'Handler' do
+  context 'Formatting' do
+    context 'Quote Columns' do
+      handler = ViewData::PG::Handler.build
+      column_name = 'example_column'
+
+      quoted_column = handler.quote_columns(column_name)
+
+      test 'adds quotes to column name' do
+        assert quoted_column == "\"#{column_name}\""
+      end
+    end
+  end
+end

--- a/test/automated/handler/formatting/quote_table.rb
+++ b/test/automated/handler/formatting/quote_table.rb
@@ -1,0 +1,27 @@
+require_relative '../../automated_init'
+
+context 'Handler' do
+  context 'Formatting' do
+    context 'Quote Table' do
+      handler = ViewData::PG::Handler.build
+
+
+      test 'non-namespaced table' do
+        name = 'table_name'
+
+        quoted_table = handler.quote_table_name(name)
+
+        assert quoted_table == "\"#{name}\""
+      end
+
+      test 'namespaced table' do
+        namespace = 'table'
+        table = 'name'
+
+        quoted_table = handler.quote_table_name("#{namespace}.#{table}")
+
+        assert quoted_table == "\"table\".\"name\""
+      end
+    end
+  end
+end


### PR DESCRIPTION
…e names

previously double quotes was always being added to table names, and as such was not properly formatting namespaced tables.
We found a class method on PG that supports adding quotes to a string, so separated the previously manual method into two
separate methods that would allow for our use case