### PR TITLE
generate sql statements with the proper formatting for table

### DIFF
--- a/lib/view_data/pg/handler.rb
+++ b/lib/view_data/pg/handler.rb
@@ -28,7 +28,7 @@ module ViewData
         columns = pkey_columns + data_columns
 
         quoted_columns = columns.map do |column|
-          double_quote(column)
+          quote_column(column)
         end
 
         values = pkey_values + data_values
@@ -38,7 +38,7 @@ module ViewData
         end
 
         statement = <<~SQL.chomp
-          INSERT INTO #{double_quote(table_name)} (#{quoted_columns * ', '})
+          INSERT INTO #{quote_table_name(table_name)} (#{quoted_columns * ', '})
           VALUES (#{values_clause * ', '})
         SQL
 
@@ -69,7 +69,7 @@ module ViewData
         data_values = update.data.values
 
         set_clause = data_columns.map.with_index do |column, index|
-          quoted_column = double_quote(column)
+          quoted_column = quote_column(column)
 
           reference = index + 1
 
@@ -77,7 +77,7 @@ module ViewData
         end
 
         pkey_clause = pkey_columns.map.with_index do |column, index|
-          quoted_column = double_quote(column)
+          quoted_column = quote_column(column)
 
           reference = index + data_columns.count + 1
 
@@ -87,7 +87,7 @@ module ViewData
         values = data_values + pkey_values
 
         statement = <<~SQL.chomp
-          UPDATE #{double_quote(table_name)}
+          UPDATE #{quote_table_name(table_name)}
           SET #{set_clause * ', '}
           WHERE #{pkey_clause * ' AND '}
         SQL
@@ -112,7 +112,7 @@ module ViewData
         pkey_values = Array(delete.identifier)
 
         pkey_clause = pkey_columns.map.with_index do |column, index|
-          quoted_column = double_quote(column)
+          quoted_column = quote_column(column)
 
           reference = index + 1
 
@@ -120,7 +120,7 @@ module ViewData
         end
 
         statement = <<~SQL.chomp
-          DELETE FROM #{double_quote(table_name)}
+          DELETE FROM #{quote_table_name(table_name)}
           WHERE #{pkey_clause * ' AND '}
         SQL
 
@@ -135,8 +135,12 @@ module ViewData
         logger.info(tag: :data) { pkey_values.pretty_inspect }
       end
 
-      def double_quote(text)
-        "\"#{text}\""
+      def quote_column(column)
+        session.connect.quote_ident(column.to_s)
+      end
+
+      def quote_table_name(name)
+        session.connect.quote_ident(name.to_s.split('.'))
       end
     end
   end

--- a/test/automated/handler/formatting/quote_column.rb
+++ b/test/automated/handler/formatting/quote_column.rb
@@ -1,0 +1,16 @@
+require_relative '../../automated_init'
+
+context 'Handler' do
+  context 'Formatting' do
+    context 'Quote Column' do
+      handler = ViewData::PG::Handler.build
+      column_name = 'example_column'
+
+      quoted_column = handler.quote_column(column_name)
+
+      test 'adds quotes to column name' do
+        assert quoted_column == "\"#{column_name}\""
+      end
+    end
+  end
+end

--- a/test/automated/handler/formatting/quote_table.rb
+++ b/test/automated/handler/formatting/quote_table.rb
@@ -1,0 +1,27 @@
+require_relative '../../automated_init'
+
+context 'Handler' do
+  context 'Formatting' do
+    context 'Quote Table' do
+      handler = ViewData::PG::Handler.build
+
+
+      test 'non-namespaced table' do
+        name = 'table_name'
+
+        quoted_table = handler.quote_table_name(name)
+
+        assert quoted_table == "\"#{name}\""
+      end
+
+      test 'namespaced table' do
+        namespace = 'table'
+        table = 'name'
+
+        quoted_table = handler.quote_table_name("#{namespace}.#{table}")
+
+        assert quoted_table == "\"table\".\"name\""
+      end
+    end
+  end
+end


### PR DESCRIPTION
previously double quotes was always being added to table names, and as such was not properly formatting namespaced tables.
We found a class method on PG that supports adding quotes to a string, so separated the previously manual method into two
separate methods that would allow for our use case